### PR TITLE
Fix failing tests and adjust import path

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,11 @@
 import os
+import sys
+
 os.environ['TESTING'] = 'true'
+
+# Ensure the application package can be imported when running tests directly
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import unittest
 from app import app
 
@@ -21,7 +27,7 @@ class TestPortfolioApp(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         html = resp.get_data(as_text=True)
         # Check for expected HTML elements and sections
-        self.assertIn("<title>MLH Fellow</title>", html)
+        self.assertIn("<title>Yifang</title>", html)
         self.assertIn('<header class="navbar', html)
         self.assertIn('<div class="profile">', html)
         self.assertIn('<section id="about"', html)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,11 @@
 import os
+import sys
+
 os.environ['TESTING'] = 'true'
+
+# Ensure the application package can be imported when running tests directly
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import unittest
 from peewee import *
 from app import TimelinePost


### PR DESCRIPTION
## Summary
- ensure tests import the `app` package even when executed directly
- update homepage test to match current page title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4b5635e083278b7af44fef98edc9